### PR TITLE
docs: don't suggest partial upgrades on Arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ sudo yum install org-stats
 #### arch linux
 
 ```sh
-yay -Sy org-stats-bin
+yay -S org-stats-bin
 ```
 
 ## stargazers over time


### PR DESCRIPTION
This is discouraged on Arch, as it can actually lead to broken installs due to a partial upgrade.