### PR TITLE
chore: bump mango and adapt to changed API

### DIFF
--- a/cmd/man.go
+++ b/cmd/man.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/muesli/mango/mcobra"
+	mcobra "github.com/muesli/mango-cobra"
 	"github.com/muesli/roff"
 	"github.com/spf13/cobra"
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/charmbracelet/lipgloss v0.4.0
 	github.com/google/go-github/v39 v39.2.0
 	github.com/matryer/is v1.4.0
-	github.com/muesli/mango v0.0.0-20220118122812-f367188b892e
+	github.com/muesli/mango-cobra v0.0.0-20220201014606-122d08dcc447
 	github.com/muesli/roff v0.1.0
 	github.com/spf13/cobra v1.3.0
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
@@ -23,6 +23,8 @@ require (
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b // indirect
+	github.com/muesli/mango v0.0.0-20220201014152-f7df5a1c5b4b // indirect
+	github.com/muesli/mango-pflag v0.0.0-20220201014449-d694870c5590 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.9.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -303,8 +303,12 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b h1:1XF24mVaiu7u+CFywTdcDo2ie1pzzhwjt6RHqzpMU34=
 github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b/go.mod h1:fQuZ0gauxyBcmsdE3ZT4NasjaRdxmbCS0jRHsrWu3Ho=
-github.com/muesli/mango v0.0.0-20220118122812-f367188b892e h1:ykZ/Hqqvqm2lmZ1YoruxTWaOb90IKlkMuT0Io9baO+A=
-github.com/muesli/mango v0.0.0-20220118122812-f367188b892e/go.mod h1:r40g5Hx6ZzbjDW0GZhCpSX2Wyt9SPSDRoQGaODqxSz4=
+github.com/muesli/mango v0.0.0-20220201014152-f7df5a1c5b4b h1:kGcKjlZqUNbpUjBMdIq5/RbA2gN9ypH0Tv+MNBtCgK4=
+github.com/muesli/mango v0.0.0-20220201014152-f7df5a1c5b4b/go.mod h1:5XFpbC8jY5UUv89YQciiXNlbi+iJgt29VDC5xbzrLL4=
+github.com/muesli/mango-cobra v0.0.0-20220201014606-122d08dcc447 h1:R3deta3TkTtx/COvHF0zlPxZlg4uG+Ekt7GMfB4vDVI=
+github.com/muesli/mango-cobra v0.0.0-20220201014606-122d08dcc447/go.mod h1:cww/23x1UfmOIUSsDI/kSsGWDKGQEkmzfN4EF66xXfA=
+github.com/muesli/mango-pflag v0.0.0-20220201014449-d694870c5590 h1:bZgkcUsck7Y6kMUcpettBv6jUck4rTrgPEBIKwFbGpM=
+github.com/muesli/mango-pflag v0.0.0-20220201014449-d694870c5590/go.mod h1:o2wTF9T2N5YEx+lHxQ6R3RsUg9NH4jyaOIlnJN5KQ04=
 github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68/go.mod h1:Xk+z4oIWdQqJzsxyjgl3P22oYZnHdZ8FFTHAQQt5BMQ=
 github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
 github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=


### PR DESCRIPTION
mango's API has changed, and the mango-cobra adapter has been moved into a separate repository. This change bumps mango and adapts org-stats's code to this API change.

See: muesli/mango#5