### PR TITLE
feat: allow excluding forks

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ var (
 	blacklist      []string
 	top            int
 	includeReviews bool
+	excludeForks   bool
 )
 
 func Execute() {
@@ -44,6 +45,7 @@ func init() {
 	rootCmd.Flags().StringVar(&githubURL, "github-url", "", "custom github base url (if using github enterprise)")
 	rootCmd.Flags().StringVar(&since, "since", "0s", "time to look back to gather info (0s means everything)")
 	rootCmd.Flags().BoolVar(&includeReviews, "include-reviews", false, "include pull request reviews in the stats")
+	rootCmd.Flags().BoolVar(&excludeForks, "exclude-forks", false, "exclude forked repositories from the stats")
 	rootCmd.Flags().StringVar(&csvPath, "csv-path", "", "path to write a csv file with all data collected")
 
 	rootCmd.CompletionOptions.HiddenDefaultCmd = true
@@ -120,6 +122,7 @@ Important notes:
 			sinceT,
 			top,
 			includeReviews,
+			excludeForks,
 			csv,
 		))
 		return p.Start()

--- a/cmd/ui/ui.go
+++ b/cmd/ui/ui.go
@@ -25,6 +25,7 @@ func NewInitialModel(
 	since time.Time,
 	top int,
 	includeReviewStats bool,
+	excludeForks bool,
 	csv io.Writer,
 ) InitialModel {
 	var s = spinner.NewModel()
@@ -38,6 +39,7 @@ func NewInitialModel(
 		repoBlacklist:      repoBlacklist,
 		since:              since,
 		includeReviewStats: includeReviewStats,
+		excludeForks:       excludeForks,
 		top:                top,
 		spinner:            s,
 		csv:                csv,
@@ -58,6 +60,7 @@ type InitialModel struct {
 	repoBlacklist      []string
 	since              time.Time
 	includeReviewStats bool
+	excludeForks       bool
 	top                int
 	csv                io.Writer
 }
@@ -71,6 +74,7 @@ func (m InitialModel) Init() tea.Cmd {
 			m.repoBlacklist,
 			m.since,
 			m.includeReviewStats,
+			m.excludeForks,
 		),
 		spinner.Tick,
 	)
@@ -124,6 +128,7 @@ func getStats(
 	userBlacklist, repoBlacklist []string,
 	since time.Time,
 	includeReviews bool,
+	excludeForks bool,
 ) tea.Cmd {
 	return func() tea.Msg {
 		stats, err := orgstats.Gather(
@@ -134,6 +139,7 @@ func getStats(
 			repoBlacklist,
 			since,
 			includeReviews,
+			excludeForks,
 		)
 		if err != nil {
 			return errMsg{err}

--- a/docs/org-stats.md
+++ b/docs/org-stats.md
@@ -32,6 +32,7 @@ org-stats [flags]
       --github-url string   custom github base url (if using github enterprise)
   -h, --help                help for org-stats
       --include-reviews     include pull request reviews in the stats
+      --exclude-forks       exclude forked repositories from the stats
   -o, --org string          github organization to scan
       --since string        time to look back to gather info (0s means everything) (default "0s")
       --token string        github api token (default $GITHUB_TOKEN)

--- a/orgstats/stats.go
+++ b/orgstats/stats.go
@@ -49,6 +49,7 @@ func Gather(
 	userBlacklist, repoBlacklist []string,
 	since time.Time,
 	includeReviewStats bool,
+	excludeForks bool,
 ) (Stats, error) {
 
 	allStats := NewStats(since)
@@ -58,6 +59,7 @@ func Gather(
 		org,
 		userBlacklist,
 		repoBlacklist,
+		excludeForks,
 		&allStats,
 	); err != nil {
 		return Stats{}, err
@@ -134,6 +136,7 @@ func gatherLineStats(
 	client *github.Client,
 	org string,
 	userBlacklist, repoBlacklist []string,
+	excludeForks bool,
 	allStats *Stats,
 ) error {
 	allRepos, err := repos(ctx, client, org)
@@ -142,6 +145,10 @@ func gatherLineStats(
 	}
 
 	for _, repo := range allRepos {
+		if excludeForks && *repo.Fork {
+			log.Println("ignoring forked repo:", repo.GetName())
+			continue
+		}
 		if isBlacklisted(repoBlacklist, repo.GetName()) {
 			log.Println("ignoring blacklisted repo:", repo.GetName())
 			continue


### PR DESCRIPTION
Adds the CLI option `--exclude-forks` to exclude all forked third-party repositories