### PR TITLE
Fix: #71 Bad Credentials

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -11,7 +11,11 @@ func newClient(ctx context.Context, token, baseURL string) (*github.Client, erro
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 
 	if baseURL == "" {
-		return github.NewClient(oauth2.NewClient(ctx, ts)), nil
+		if token == "" {
+			return github.NewClient(nil), nil
+		} else {
+			return github.NewClient(oauth2.NewClient(ctx, ts)), nil
+		}
 	}
 
 	return github.NewEnterpriseClient(baseURL, "", oauth2.NewClient(ctx, ts))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,6 +65,7 @@ Finally, it prints a rank by each category.
 
 
 Important notes:
+* GitHub's API rate limits for unauthenticated requests have been lowered significantly in the recent past. Using the ` + "`--token`" + ` option for compiling stats will speed up gathering of data considerably, since for authenticated requests it will be less likely that rate-limiting timelocks have to be awaited.
 * The ` + "`--since`" + ` filter does not work "that well" because GitHub summarizes thedata by week, so the data is not as granular as it should be.
 * The ` + "`--include-reviews`" + ` only grabs reviews from users that had contributions on the previous step.
 * In the ` + "`--blacklist`" + ` option, 'foo' blacklists both the 'foo' user and 'foo' repo, while 'user:foo' blacklists only the user and 'repo:foo' only the repository.


### PR DESCRIPTION
Changes
* uses an unauthenticated GitHub client if no token was provided (closes #71)
* adds a note about GitHub rate-limits